### PR TITLE
Fix for predict-seg-redis.py

### DIFF
--- a/yolov5/2022-11-05_cpu/predict_seg_redis.py
+++ b/yolov5/2022-11-05_cpu/predict_seg_redis.py
@@ -5,7 +5,7 @@ import traceback
 
 from datetime import datetime
 from rdh import Container, MessageContainer, create_parser, configure_redis, run_harness, log
-from predict_common import load_model, prepare_image, predict_image_opex
+from predict_common import load_model, prepare_image, predict_segmentation_opex
 
 
 def process_image(msg_cont):
@@ -25,12 +25,12 @@ def process_image(msg_cont):
         jpg_as_np = np.frombuffer(msg_cont.message['data'], dtype=np.uint8)
         im0 = cv2.imdecode(jpg_as_np, flags=1)
         im = prepare_image(im0, config.image_size, config.model.fp16, config.model.stride, config.device)
-        preds = predict_image_opex(config.model,
-                                   str(start_time),
-                                   im, im0,
-                                   confidence_threshold=config.confidence_threshold,
-                                   iou_threshold=config.iou_threshold,
-                                   max_detection=config.max_detection)
+        preds = predict_segmentation_opex(config.model,
+                                          str(start_time),
+                                          im, im0,
+                                          confidence_threshold=config.confidence_threshold,
+                                          iou_threshold=config.iou_threshold,
+                                          max_detection=config.max_detection)
         preds_str = preds.to_json_string()
         msg_cont.params.redis.publish(msg_cont.params.channel_out, preds_str)
         if config.verbose:

--- a/yolov5/2022-11-05_cuda11.1/predict_seg_redis.py
+++ b/yolov5/2022-11-05_cuda11.1/predict_seg_redis.py
@@ -5,7 +5,7 @@ import traceback
 
 from datetime import datetime
 from rdh import Container, MessageContainer, create_parser, configure_redis, run_harness, log
-from predict_common import load_model, prepare_image, predict_image_opex
+from predict_common import load_model, prepare_image, predict_segmentation_opex
 
 
 def process_image(msg_cont):
@@ -25,12 +25,12 @@ def process_image(msg_cont):
         jpg_as_np = np.frombuffer(msg_cont.message['data'], dtype=np.uint8)
         im0 = cv2.imdecode(jpg_as_np, flags=1)
         im = prepare_image(im0, config.image_size, config.model.fp16, config.model.stride, config.device)
-        preds = predict_image_opex(config.model,
-                                   str(start_time),
-                                   im, im0,
-                                   confidence_threshold=config.confidence_threshold,
-                                   iou_threshold=config.iou_threshold,
-                                   max_detection=config.max_detection)
+        preds = predict_segmentation_opex(config.model,
+                                          str(start_time),
+                                          im, im0,
+                                          confidence_threshold=config.confidence_threshold,
+                                          iou_threshold=config.iou_threshold,
+                                          max_detection=config.max_detection)
         preds_str = preds.to_json_string()
         msg_cont.params.redis.publish(msg_cont.params.channel_out, preds_str)
         if config.verbose:


### PR DESCRIPTION
Hello `fracpete`,

I use your framework and also wanted to contribute back - please review my minor fix below.
I really appreciate your work on bringing the user friendliness into machine learning!
Thanks and keep up the great work! 👍 

When using **instance segmentation through Redis**, every image sent causes the following error:
```
Loading model...
YOLOv5  v6.2-226-gfde7758 Python-3.9.2 torch-1.9.1+cu102 CPU

Fusing layers...
YOLOv5m-seg summary: 220 layers, 21652358 parameters, 0 gradients, 69.8 GFLOPs
2023-01-07 19:14:25.756680 -  process_images - start processing image
2023-01-07 19:14:27.407194 -  process_images - failed to process: Traceback (most recent call last):
  File "/opt/yolov5/predict_seg_redis.py", line 28, in process_image
    preds = predict_image_opex(config.model,
  File "/opt/yolov5/predict_common.py", line 95, in predict_image_opex
    #                label = model.names[int(d[5])]
KeyError: 24
```

It turns out `predict-seg-redis.py` incorrectly calls `predict_image_opex()`. \
The fix is simple: to correctly call `predict_segmentation_opex()` instead.